### PR TITLE
RadioQTama改為使用gitlab api直鏈

### DIFF
--- a/QuonTama/QuonTamaRadioQTamaList.js
+++ b/QuonTama/QuonTamaRadioQTamaList.js
@@ -20,10 +20,10 @@ var myPlaylist = (typeof myPlaylist === 'undefined') ? [] : myPlaylist;
      * @type {*[]}
      */
     var newPlaylist = [
-        ['tj-lHz1dJs4', 0, 0, '#0 アニメ『ソードアート・オンライン』を語る！', 'https://gitlab.com/alubaato/tama-subs/-/raw/master/Qtama/%230%E3%80%90%E3%83%A9%E3%82%B8%E3%82%AAQtama%E3%80%91%E3%82%A2%E3%83%8B%E3%83%A1%E3%80%8E%E3%82%BD%E3%83%BC%E3%83%89%E3%82%A2%E3%83%BC%E3%83%88%E3%83%BB%E3%82%AA%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%B3%E3%80%8F%E3%82%92%E8%AA%9E%E3%82%8B%EF%BC%81%E3%80%90%E6%96%B0%E4%BA%BAVtuber%EF%BC%8F%E4%B9%85%E9%81%A0%E3%81%9F%E3%81%BE%E3%80%91.ass'],
-        ['zbp1ZpZHxNM', 0, 0, '#1 アニメ『はたらく細胞』を語る！', 'https://gitlab.com/alubaato/tama-subs/-/raw/master/Qtama/%231%E3%80%90%E3%83%A9%E3%82%B8%E3%82%AAQtama%E3%80%91%E3%82%A2%E3%83%8B%E3%83%A1%E3%80%8E%E3%81%AF%E3%81%9F%E3%82%89%E3%81%8F%E7%B4%B0%E8%83%9E%E3%80%8F%E3%82%92%E8%AA%9E%E3%82%8B%EF%BC%81%E3%80%90%E6%96%B0%E4%BA%BAVtuber%EF%BC%8F%E4%B9%85%E9%81%A0%E3%81%9F%E3%81%BE%E3%80%91.ass'],
-        ['Qvfvsgz8MEU', 0, 0, '#2 アニメ『ホリミヤ』を語る！', 'https://gitlab.com/alubaato/tama-subs/-/raw/master/Qtama/%232%E3%80%90%E3%83%A9%E3%82%B8%E3%82%AAQtama%E3%80%91%E3%82%A2%E3%83%8B%E3%83%A1%E3%80%8E%E3%80%8F%E3%82%92%E8%AA%9E%E3%82%8B%EF%BC%81%E3%80%90%E6%96%B0%E4%BA%BAVtuber%EF%BC%8F%E4%B9%85%E9%81%A0%E3%81%9F%E3%81%BE%E3%80%91-Qvfvsgz8MEU.ass'],
-        ['9LuK87QodS4', 0, 0, '#3 アニメ『進撃の巨人』を語る！', 'https://gitlab.com/alubaato/tama-subs/-/raw/master/Qtama/%233%E3%80%90%E3%83%A9%E3%82%B8%E3%82%AAQtama%E3%80%91%E3%82%A2%E3%83%8B%E3%83%A1%E3%80%8E%E9%80%B2%E6%92%83%E3%81%AE%E5%B7%A8%E4%BA%BA%E3%80%8F%E3%82%92%E8%AA%9E%E3%82%8B%EF%BC%81%E3%80%90%E6%96%B0%E4%BA%BAVtuber%EF%BC%8F%E4%B9%85%E9%81%A0%E3%81%9F%E3%81%BE%E3%80%91.ass'],
+        ['tj-lHz1dJs4', 0, 0, '#0 アニメ『ソードアート・オンライン』を語る！', 'https://gitlab.com/api/v4/projects/23810267/repository/blobs/202b0a979c8414f5c01e640f957d292e32ea1eeb/raw'],
+        ['zbp1ZpZHxNM', 0, 0, '#1 アニメ『はたらく細胞』を語る！', 'https://gitlab.com/api/v4/projects/23810267/repository/blobs/202b0a979c8414f5c01e640f957d292e32ea1eeb/raw'],
+        ['Qvfvsgz8MEU', 0, 0, '#2 アニメ『ホリミヤ』を語る！', 'https://gitlab.com/api/v4/projects/23810267/repository/blobs/683bde2e7e19f3a672623e364e73c94c434a403b/raw'],
+        ['9LuK87QodS4', 0, 0, '#3 アニメ『進撃の巨人』を語る！', 'https://gitlab.com/api/v4/projects/23810267/repository/blobs/2b49206db57ac2c51d810538b8e3671fd8a6a154/raw'],
     ];
 
     /** 載入判斷 **/


### PR DESCRIPTION
之後預計改寫為使用gitlab tree api自動取blob id來兜網址

Gitlab API 詳細:
https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree
https://docs.gitlab.com/ee/api/repositories.html#raw-blob-content